### PR TITLE
Small fix in gauge background border

### DIFF
--- a/dual-gauge-card.js
+++ b/dual-gauge-card.js
@@ -278,7 +278,7 @@ class DualGaugeCard extends HTMLElement {
       }
 
       .gauge-background .circle {
-        border: calc(var(--gauge-width) * 2 - 1px) solid #e5e5e5;
+        border: calc(var(--gauge-width) * 2 - 2px) solid #e5e5e5;
       }
 
       .gauge-title {


### PR DESCRIPTION
Change the gauge background border calculate to fit better in dark themes.
Before:
<img width="784" alt="screen shot 2018-08-26 at 19 29 30" src="https://user-images.githubusercontent.com/10164935/44631757-4e06b700-a979-11e8-9acc-1b67a600c734.png">
After:
<img width="789" alt="screen shot 2018-08-26 at 19 31 19" src="https://user-images.githubusercontent.com/10164935/44631760-55c65b80-a979-11e8-923e-80ff0db94514.png">
